### PR TITLE
Fix content uri for downloaded files on Android 10(API 29)

### DIFF
--- a/android/src/main/java/com/croppingimagepicker/CroppingImagePickerModule.kt
+++ b/android/src/main/java/com/croppingimagepicker/CroppingImagePickerModule.kt
@@ -316,14 +316,7 @@ class CroppingImagePickerModule(private val reactContext: ReactApplicationContex
       when {
         cropping || mediaType == "photo" -> {
           galleryIntent.type = "image/*"
-//          if (cropping) {
-//            galleryIntent.putExtra(
-//              Intent.EXTRA_MIME_TYPES,
-//              arrayOf("image/jpeg", "image/png")
-//            )
-//          }
         }
-
         mediaType == "video" -> galleryIntent.type = "video/*"
         else -> {
           galleryIntent.type = "*/*"

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -5,10 +5,14 @@
   <uses-permission android:name="android.permission.CAMERA" />
   <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
   <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+  <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
 
   <uses-feature android:name="android.hardware.location.gps" />
   <uses-feature
     android:name="android.hardware.camera"
+    android:required="false" />
+  <uses-feature
+    android:name="android.hardware.camera.front"
     android:required="false" />
 
   <application

--- a/example/package.json
+++ b/example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-cropping-image-picker-example",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "private": true,
   "scripts": {
     "android": "react-native run-android",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-cropping-image-picker",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Cropping and Picking Images",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
Changes:

- Add logic to handle file Ids from downloaded folder in Android 10 (API 29)
- Add missing permissions in example app (for Android 13 (API 33+))