### PR TITLE
feat(maintenance): remove deprecated UIGraphicsBeginImageContext

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -376,7 +376,7 @@ PODS:
   - React-jsinspector (0.72.14)
   - React-logger (0.72.14):
     - glog
-  - react-native-cropping-image-picker (0.3.0):
+  - react-native-cropping-image-picker (0.4.2):
     - CropViewController
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
@@ -704,7 +704,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: e9a70be9304ef2e66eeebac35710f958b076dc14
   React-jsinspector: 275d9f80210f15f0af9a4b7fd5683fab9738e28e
   React-logger: 8da4802de77a0eb62512396ad6bb1769904c2f0e
-  react-native-cropping-image-picker: 57b811181fe80651f79aea152df1dca35c5761dd
+  react-native-cropping-image-picker: e8d1e8a79b636017b8dea4d6c5250a5f382d8a09
   react-native-video: c26780b224543c62d5e1b2a7244a5cd1b50e8253
   React-NativeModulesApple: 3107f777453f953906d9ba9dc5f8cbd91a6ef913
   React-perflogger: daabc494c6328efc1784a4b49b8b74fca305d11c

--- a/ios/Compression.swift
+++ b/ios/Compression.swift
@@ -19,7 +19,6 @@ class Compression {
         self.exportPresets = dic
     }
     
-//    func compressImageDimensions(image: UIImage, maxWidth: CGFloat, maxHeight: CGFloat, into result: ImageResult) -> ImageResult {
     func compressImageDimensions(image: UIImage, maxWidth: CGFloat, maxHeight: CGFloat, into result: ImageResult) {
         let oldWidth = image.size.width
         let oldHeight = image.size.height
@@ -37,15 +36,14 @@ class Compression {
         
         let newSize = CGSize(width: newWidth, height: newHeight)
         
-        UIGraphicsBeginImageContext(newSize)
-        image.draw(in: CGRect(x: 0, y: 0, width: newSize.width, height: newSize.height))
-        let resizedImage = UIGraphicsGetImageFromCurrentImageContext()
-        UIGraphicsEndImageContext()
+        let renderer = UIGraphicsImageRenderer(size: newSize)
+        let resizedImage = renderer.image { (context) in
+            image.draw(in: CGRect(x: 0, y: 0, width: newSize.width, height: newSize.height))
+        }
         
         result.width = NSNumber(value: newWidth)
         result.height = NSNumber(value: newHeight)
         result.image = resizedImage
-//        return result
     }
     
     func compressImage(image: UIImage, with options: [String: Any]) -> ImageResult {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit b2904437cc535c70cca1f30e61b97dfae1909985  | 
|--------|--------|

### Summary:
Replaced deprecated `UIGraphicsBeginImageContext` with `UIGraphicsImageRenderer` in `ios/Compression.swift` and updated `react-native-cropping-image-picker` in `example/ios/Podfile.lock`.

**Key points**:
- Updated `compressImageDimensions` in `ios/Compression.swift` to use `UIGraphicsImageRenderer`.
- Removed deprecated `UIGraphicsBeginImageContext` usage.
- Improved image resizing performance and memory management.
- Updated `example/ios/Podfile.lock` for `react-native-cropping-image-picker` from `0.3.0` to `0.4.2`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->