### PR TITLE
feat(maintenance): adjust privacy manifest

### DIFF
--- a/ios/PrivacyInfo.xcprivacy
+++ b/ios/PrivacyInfo.xcprivacy
@@ -1,38 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-    <dict>
-        <key>NSPrivacyTracking</key>
-        <false/>
-        <key>NSPrivacyTrackingDomains</key>
-        <array>
-            <string></string>
-        </array>
-        <key>NSPrivacyAccessedAPITypes</key>
-        <array>
-            <dict>
-                <key>NSPrivacyAccessedAPITypeReasons</key>
-                <array>
-                    <string>3B52.1</string>
-                </array>
-                <key>NSPrivacyAccessedAPIType</key>
-                <string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
-            </dict>
-        </array>
-        <key>NSPrivacyCollectedDataTypes</key>
-        <array>
-            <dict>
-                <key>NSPrivacyCollectedDataType</key>
-                <string>NSPrivacyCollectedDataTypePhotosorVideos</string>
-                <key>NSPrivacyCollectedDataTypeLinked</key>
-                <true/>
-                <key>NSPrivacyCollectedDataTypeTracking</key>
-                <false/>
-                <key>NSPrivacyCollectedDataTypePurposes</key>
-                <array>
-                    <string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
-                </array>
-            </dict>
-        </array>
-    </dict>
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>3B52.1</string>
+			</array>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+		</dict>
+	</array>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypePhotosorVideos</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<true/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+		</dict>
+	</array>
+</dict>
 </plist>


### PR DESCRIPTION
Change due to invalid content for `PrivacyInfo.xprivacy`

> ITMS-91107: Invalid tracking information - A PrivacyInfo.xcprivacy file contains invalid tracking information at the following path: “RNCroppingImagePickerPrivacyInfo.bundle/PrivacyInfo.xcprivacy”. In addition to the privacy manifest files in the locations outlined in the documentation, starting November 12, 2024, all privacy manifests you submit must have valid content. NSPrivacyTracking must be true if NSPrivacyTrackingDomains isn’t empty. Keys and values in any privacy manifest must be valid. For more details, visit: https://developer.apple.com/documentation/bundleresources/privacy_manifest_files and https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/adding_a_privacy_manifest_to_your_app_or_third-party_sdk.
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 5444c1bfbe13a9fff4eb2531092c972d5b6c19ff  | 
|--------|--------|

### Summary:
The `ios/PrivacyInfo.xcprivacy` file is updated to remove invalid tracking information by deleting `NSPrivacyTracking` and `NSPrivacyTrackingDomains` keys.

**Key points**:
- Modify `ios/PrivacyInfo.xcprivacy` to remove invalid tracking information.
- Remove `NSPrivacyTracking` key previously set to `false`.
- Remove `NSPrivacyTrackingDomains` key previously set to an empty array.
- Retain `NSPrivacyAccessedAPITypes` and `NSPrivacyCollectedDataTypes` sections.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->